### PR TITLE
Add native child program runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,44 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(VECTOR VERSION 0.1.0 LANGUAGES C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+add_library(vector_child_program_runtime STATIC
+  src/child_program_runtime.c
+)
+
+target_include_directories(vector_child_program_runtime
+  PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+
+if(MSVC)
+  target_compile_options(vector_child_program_runtime PRIVATE /W4)
+else()
+  target_compile_options(vector_child_program_runtime PRIVATE -Wall -Wextra -Wpedantic)
+endif()
+
+enable_testing()
+
+add_executable(vector_child_program_runtime_tests
+  tests/test_child_program_runtime.c
+)
+
+target_link_libraries(vector_child_program_runtime_tests
+  PRIVATE
+    vector_child_program_runtime
+)
+
+if(MSVC)
+  target_compile_options(vector_child_program_runtime_tests PRIVATE /W4)
+else()
+  target_compile_options(vector_child_program_runtime_tests PRIVATE -Wall -Wextra -Wpedantic)
+endif()
+
+add_test(
+  NAME vector_child_program_runtime_tests
+  COMMAND vector_child_program_runtime_tests
+)

--- a/README.md
+++ b/README.md
@@ -53,9 +53,21 @@ The first concrete topology slice lives in [`docs/vector-runtime-topology-first-
 
 The first bounded main-program decomposition lives in [`docs/vector-main-child-program-first-slice.md`](docs/vector-main-child-program-first-slice.md).
 
+The first Native C child-program ABI lives in [`include/vector/child_program_runtime.h`](include/vector/child_program_runtime.h). It exposes ABI/schema versions, first-class child-program descriptors, workspace-region routing, stable status names, and CORTEX character/component reference fields for the main interaction program.
+
 The first upstream Codex component assimilation map lives in [`docs/openai-codex-component-assimilation-map.md`](docs/openai-codex-component-assimilation-map.md), with a generated local upstream manifest at [`docs/openai-codex-upstream-manifest.json`](docs/openai-codex-upstream-manifest.json).
 
 The explicit CORTEX-to-VECTOR execution boundary now lives in [`docs/vector-character-consumer-boundary.md`](docs/vector-character-consumer-boundary.md).
+
+## Native Build
+
+Configure, build, and run the native child-program runtime tests with:
+
+```powershell
+cmake -S . -B "$env:LOCALAPPDATA\VECTOR\child-program-runtime-build"
+cmake --build "$env:LOCALAPPDATA\VECTOR\child-program-runtime-build" --config Debug
+ctest --test-dir "$env:LOCALAPPDATA\VECTOR\child-program-runtime-build" -C Debug --output-on-failure
+```
 
 ## Upstream Manifest
 

--- a/docs/vector-main-child-program-first-slice.md
+++ b/docs/vector-main-child-program-first-slice.md
@@ -48,6 +48,9 @@ These are candidates, not yet first-class runtime programs in the same way as th
 
 - The current usable repo lane is still the Codex Workbench Electron prototype.
 - The Native C plus Avalonia lane now owns the `vector_main_child_program_contract` that defines the first child-program boundary for VECTOR.
+- The first executable Native C contract is now `include/vector/child_program_runtime.h`, backed by `src/child_program_runtime.c` and `tests/test_child_program_runtime.c`.
+- That contract exposes the two first-class child programs as stable descriptors and routes workspace regions to those descriptors without requiring managed shell ownership.
+- `vector-main-interaction-program` routes only when a CORTEX character and component reference are present; VECTOR consumes those references but does not own CORTEX identity or lifecycle authority.
 - The Avalonia host now renders dedicated left-side menu and main interaction program regions from that runtime contract instead of leaving the split implicit in one generic payload pane.
 - The Avalonia host now routes the main interaction region to a bounded upstream Codex-style conversation-summary, selected-turn detail, tool/payload preview, execution-result and approval-resolution continuity, approval/artifact continuity, and turn-flow preview by default, using the upstream app-server protocol and test shapes as the source contract.
 - The first upstream `openai/codex` assimilation map now treats `codex-rs/tui`, `codex-rs/core`, `codex-rs/protocol`, `codex-rs/app-server-protocol`, `codex-rs/exec`, and `codex-rs/apply-patch` as priority sources for the main interaction child and its follow-on tool, approval, artifact, and session child programs.

--- a/docs/vector-runtime-topology-first-slice.md
+++ b/docs/vector-runtime-topology-first-slice.md
@@ -76,6 +76,8 @@ It is intentionally bounded. It does not describe every future subsystem. It def
 - Current CODEX continuity work may still expose bounded seams through the Codex Workbench line.
 - Those seams should keep reporting `FLUXBASE`, `DEVBASE`, `CODEBASE`, and `CHATBASE` explicitly rather than collapsing state back into one local app store.
 - Upstream `openai/codex` session and retrieval behavior can still be assimilated, but the authoritative lane for forward VECTOR memory remains `DEVBASE`, not SQLite.
+- The first native C runtime slice now exposes workspace-region routing through `vector_child_program_route_region`, so the Avalonia host can ask the native runtime for the governing child-program descriptor before rendering left-menu or main-interaction regions.
+- The main-interaction route requires CORTEX character and component references, preserving CORTEX ownership of character/component identity while letting VECTOR consume that state for workspace execution.
 
 ## Completed next slice
 

--- a/include/vector/child_program_runtime.h
+++ b/include/vector/child_program_runtime.h
@@ -1,0 +1,104 @@
+#ifndef VECTOR_CHILD_PROGRAM_RUNTIME_H
+#define VECTOR_CHILD_PROGRAM_RUNTIME_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define VECTOR_CHILD_PROGRAM_RUNTIME_ABI_VERSION 1u
+#define VECTOR_CHILD_PROGRAM_RUNTIME_SCHEMA_VERSION 1u
+
+typedef enum vector_child_program_status {
+  VECTOR_CHILD_PROGRAM_STATUS_OK = 0,
+  VECTOR_CHILD_PROGRAM_STATUS_NULL_ARGUMENT = 1,
+  VECTOR_CHILD_PROGRAM_STATUS_UNSUPPORTED_ABI = 2,
+  VECTOR_CHILD_PROGRAM_STATUS_UNKNOWN_REGION = 3,
+  VECTOR_CHILD_PROGRAM_STATUS_MISSING_CORTEX_REFERENCE = 4
+} vector_child_program_status;
+
+typedef enum vector_workspace_region {
+  VECTOR_WORKSPACE_REGION_LEFT_MENU = 1,
+  VECTOR_WORKSPACE_REGION_MAIN_INTERACTION = 2
+} vector_workspace_region;
+
+typedef enum vector_child_program_kind {
+  VECTOR_CHILD_PROGRAM_KIND_MAIN_PROGRAM = 1,
+  VECTOR_CHILD_PROGRAM_KIND_LEFT_MENU = 2,
+  VECTOR_CHILD_PROGRAM_KIND_MAIN_INTERACTION = 3
+} vector_child_program_kind;
+
+typedef enum vector_data_lane {
+  VECTOR_DATA_LANE_NONE = 0,
+  VECTOR_DATA_LANE_FLUXBASE = 1,
+  VECTOR_DATA_LANE_DEVBASE = 2,
+  VECTOR_DATA_LANE_CODEBASE = 3,
+  VECTOR_DATA_LANE_CHATBASE = 4
+} vector_data_lane;
+
+typedef enum vector_child_program_flags {
+  VECTOR_CHILD_PROGRAM_FLAG_FIRST_CLASS = 1u << 0,
+  VECTOR_CHILD_PROGRAM_FLAG_REQUIRES_CORTEX_COMPONENT = 1u << 1,
+  VECTOR_CHILD_PROGRAM_FLAG_UPSTREAM_CODEX_ASSIMILATION = 1u << 2
+} vector_child_program_flags;
+
+typedef struct vector_cortex_reference {
+  const char *character_id;
+  const char *component_id;
+  const char *subagent_instance_id;
+} vector_cortex_reference;
+
+typedef struct vector_child_program_descriptor {
+  uint32_t abi_version;
+  uint32_t schema_version;
+  const char *program_id;
+  const char *display_label;
+  vector_workspace_region region;
+  vector_child_program_kind kind;
+  vector_data_lane primary_lane;
+  uint32_t flags;
+  const char *assimilation_source;
+} vector_child_program_descriptor;
+
+typedef struct vector_child_program_route_request {
+  uint32_t abi_version;
+  vector_workspace_region region;
+  const char *operation_id;
+  vector_cortex_reference cortex;
+} vector_child_program_route_request;
+
+typedef struct vector_child_program_route {
+  uint32_t abi_version;
+  uint32_t schema_version;
+  vector_child_program_status status;
+  vector_child_program_descriptor descriptor;
+  vector_cortex_reference cortex;
+  const char *status_message;
+} vector_child_program_route;
+
+uint32_t vector_child_program_runtime_abi_version(void);
+uint32_t vector_child_program_runtime_schema_version(void);
+
+size_t vector_child_program_count(void);
+
+vector_child_program_status vector_child_program_at(
+  size_t index,
+  vector_child_program_descriptor *out_descriptor
+);
+
+vector_child_program_status vector_child_program_route_region(
+  const vector_child_program_route_request *request,
+  vector_child_program_route *out_route
+);
+
+const char *vector_child_program_status_name(vector_child_program_status status);
+const char *vector_data_lane_name(vector_data_lane lane);
+const char *vector_workspace_region_name(vector_workspace_region region);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/child_program_runtime.c
+++ b/src/child_program_runtime.c
@@ -1,0 +1,188 @@
+#include "vector/child_program_runtime.h"
+
+#include <string.h>
+
+static const vector_child_program_descriptor k_child_programs[] = {
+  {
+    VECTOR_CHILD_PROGRAM_RUNTIME_ABI_VERSION,
+    VECTOR_CHILD_PROGRAM_RUNTIME_SCHEMA_VERSION,
+    "vector-left-menu-program",
+    "Left-side menu",
+    VECTOR_WORKSPACE_REGION_LEFT_MENU,
+    VECTOR_CHILD_PROGRAM_KIND_LEFT_MENU,
+    VECTOR_DATA_LANE_DEVBASE,
+    VECTOR_CHILD_PROGRAM_FLAG_FIRST_CLASS,
+    "openai/codex app navigation and workspace selection behavior"
+  },
+  {
+    VECTOR_CHILD_PROGRAM_RUNTIME_ABI_VERSION,
+    VECTOR_CHILD_PROGRAM_RUNTIME_SCHEMA_VERSION,
+    "vector-main-interaction-program",
+    "Main interaction",
+    VECTOR_WORKSPACE_REGION_MAIN_INTERACTION,
+    VECTOR_CHILD_PROGRAM_KIND_MAIN_INTERACTION,
+    VECTOR_DATA_LANE_DEVBASE,
+    VECTOR_CHILD_PROGRAM_FLAG_FIRST_CLASS |
+      VECTOR_CHILD_PROGRAM_FLAG_REQUIRES_CORTEX_COMPONENT |
+      VECTOR_CHILD_PROGRAM_FLAG_UPSTREAM_CODEX_ASSIMILATION,
+    "openai/codex session, turn, approval, artifact, and tool interaction behavior"
+  }
+};
+
+static const size_t k_child_program_count =
+  sizeof(k_child_programs) / sizeof(k_child_programs[0]);
+
+static int is_blank(const char *value) {
+  return value == NULL || value[0] == '\0';
+}
+
+static void reset_route(vector_child_program_route *route) {
+  if (route != NULL) {
+    memset(route, 0, sizeof(*route));
+    route->abi_version = VECTOR_CHILD_PROGRAM_RUNTIME_ABI_VERSION;
+    route->schema_version = VECTOR_CHILD_PROGRAM_RUNTIME_SCHEMA_VERSION;
+  }
+}
+
+static const vector_child_program_descriptor *find_descriptor(
+  vector_workspace_region region
+) {
+  size_t index = 0u;
+
+  for (index = 0u; index < k_child_program_count; ++index) {
+    if (k_child_programs[index].region == region) {
+      return &k_child_programs[index];
+    }
+  }
+
+  return NULL;
+}
+
+uint32_t vector_child_program_runtime_abi_version(void) {
+  return VECTOR_CHILD_PROGRAM_RUNTIME_ABI_VERSION;
+}
+
+uint32_t vector_child_program_runtime_schema_version(void) {
+  return VECTOR_CHILD_PROGRAM_RUNTIME_SCHEMA_VERSION;
+}
+
+size_t vector_child_program_count(void) {
+  return k_child_program_count;
+}
+
+vector_child_program_status vector_child_program_at(
+  size_t index,
+  vector_child_program_descriptor *out_descriptor
+) {
+  if (out_descriptor == NULL) {
+    return VECTOR_CHILD_PROGRAM_STATUS_NULL_ARGUMENT;
+  }
+
+  memset(out_descriptor, 0, sizeof(*out_descriptor));
+
+  if (index >= k_child_program_count) {
+    return VECTOR_CHILD_PROGRAM_STATUS_UNKNOWN_REGION;
+  }
+
+  *out_descriptor = k_child_programs[index];
+  return VECTOR_CHILD_PROGRAM_STATUS_OK;
+}
+
+vector_child_program_status vector_child_program_route_region(
+  const vector_child_program_route_request *request,
+  vector_child_program_route *out_route
+) {
+  const vector_child_program_descriptor *descriptor = NULL;
+
+  if (out_route == NULL) {
+    return VECTOR_CHILD_PROGRAM_STATUS_NULL_ARGUMENT;
+  }
+
+  reset_route(out_route);
+
+  if (request == NULL) {
+    out_route->status = VECTOR_CHILD_PROGRAM_STATUS_NULL_ARGUMENT;
+    out_route->status_message = "null argument";
+    return out_route->status;
+  }
+
+  if (request->abi_version != VECTOR_CHILD_PROGRAM_RUNTIME_ABI_VERSION) {
+    out_route->status = VECTOR_CHILD_PROGRAM_STATUS_UNSUPPORTED_ABI;
+    out_route->status_message = "unsupported ABI version";
+    return out_route->status;
+  }
+
+  descriptor = find_descriptor(request->region);
+  if (descriptor == NULL) {
+    out_route->status = VECTOR_CHILD_PROGRAM_STATUS_UNKNOWN_REGION;
+    out_route->status_message = "workspace region is not routed to a child program";
+    return out_route->status;
+  }
+
+  out_route->descriptor = *descriptor;
+  out_route->cortex = request->cortex;
+
+  if (
+    (descriptor->flags & VECTOR_CHILD_PROGRAM_FLAG_REQUIRES_CORTEX_COMPONENT) !=
+    0u
+  ) {
+    if (
+      is_blank(request->cortex.character_id) ||
+      is_blank(request->cortex.component_id)
+    ) {
+      out_route->status = VECTOR_CHILD_PROGRAM_STATUS_MISSING_CORTEX_REFERENCE;
+      out_route->status_message =
+        "routed child program requires CORTEX character and component references";
+      return out_route->status;
+    }
+  }
+
+  out_route->status = VECTOR_CHILD_PROGRAM_STATUS_OK;
+  out_route->status_message = "routed";
+  return out_route->status;
+}
+
+const char *vector_child_program_status_name(vector_child_program_status status) {
+  switch (status) {
+    case VECTOR_CHILD_PROGRAM_STATUS_OK:
+      return "ok";
+    case VECTOR_CHILD_PROGRAM_STATUS_NULL_ARGUMENT:
+      return "null_argument";
+    case VECTOR_CHILD_PROGRAM_STATUS_UNSUPPORTED_ABI:
+      return "unsupported_abi";
+    case VECTOR_CHILD_PROGRAM_STATUS_UNKNOWN_REGION:
+      return "unknown_region";
+    case VECTOR_CHILD_PROGRAM_STATUS_MISSING_CORTEX_REFERENCE:
+      return "missing_cortex_reference";
+    default:
+      return "unknown_status";
+  }
+}
+
+const char *vector_data_lane_name(vector_data_lane lane) {
+  switch (lane) {
+    case VECTOR_DATA_LANE_NONE:
+      return "none";
+    case VECTOR_DATA_LANE_FLUXBASE:
+      return "fluxbase";
+    case VECTOR_DATA_LANE_DEVBASE:
+      return "devbase";
+    case VECTOR_DATA_LANE_CODEBASE:
+      return "codebase";
+    case VECTOR_DATA_LANE_CHATBASE:
+      return "chatbase";
+    default:
+      return "unknown_lane";
+  }
+}
+
+const char *vector_workspace_region_name(vector_workspace_region region) {
+  switch (region) {
+    case VECTOR_WORKSPACE_REGION_LEFT_MENU:
+      return "left_menu";
+    case VECTOR_WORKSPACE_REGION_MAIN_INTERACTION:
+      return "main_interaction";
+    default:
+      return "unknown_region";
+  }
+}

--- a/tests/test_child_program_runtime.c
+++ b/tests/test_child_program_runtime.c
@@ -1,0 +1,176 @@
+#include "vector/child_program_runtime.h"
+
+#include <assert.h>
+#include <stddef.h>
+#include <string.h>
+
+static void test_version_contract(void) {
+  assert(
+    vector_child_program_runtime_abi_version() ==
+    VECTOR_CHILD_PROGRAM_RUNTIME_ABI_VERSION
+  );
+  assert(
+    vector_child_program_runtime_schema_version() ==
+    VECTOR_CHILD_PROGRAM_RUNTIME_SCHEMA_VERSION
+  );
+}
+
+static void test_descriptor_table(void) {
+  vector_child_program_descriptor descriptor;
+
+  assert(vector_child_program_count() == 2u);
+  assert(
+    vector_child_program_at(0u, &descriptor) == VECTOR_CHILD_PROGRAM_STATUS_OK
+  );
+  assert(strcmp(descriptor.program_id, "vector-left-menu-program") == 0);
+  assert(descriptor.region == VECTOR_WORKSPACE_REGION_LEFT_MENU);
+  assert(descriptor.primary_lane == VECTOR_DATA_LANE_DEVBASE);
+
+  assert(
+    vector_child_program_at(1u, &descriptor) == VECTOR_CHILD_PROGRAM_STATUS_OK
+  );
+  assert(strcmp(descriptor.program_id, "vector-main-interaction-program") == 0);
+  assert(descriptor.region == VECTOR_WORKSPACE_REGION_MAIN_INTERACTION);
+  assert(
+    (descriptor.flags & VECTOR_CHILD_PROGRAM_FLAG_REQUIRES_CORTEX_COMPONENT) !=
+    0u
+  );
+}
+
+static void test_left_menu_routes_without_cortex_reference(void) {
+  vector_child_program_route route;
+  const vector_child_program_route_request request = {
+    VECTOR_CHILD_PROGRAM_RUNTIME_ABI_VERSION,
+    VECTOR_WORKSPACE_REGION_LEFT_MENU,
+    "open-workspace",
+    { 0 }
+  };
+
+  assert(
+    vector_child_program_route_region(&request, &route) ==
+    VECTOR_CHILD_PROGRAM_STATUS_OK
+  );
+  assert(route.status == VECTOR_CHILD_PROGRAM_STATUS_OK);
+  assert(strcmp(route.descriptor.program_id, "vector-left-menu-program") == 0);
+  assert(route.cortex.character_id == NULL);
+}
+
+static void test_main_interaction_requires_cortex_reference(void) {
+  vector_child_program_route route;
+  const vector_child_program_route_request request = {
+    VECTOR_CHILD_PROGRAM_RUNTIME_ABI_VERSION,
+    VECTOR_WORKSPACE_REGION_MAIN_INTERACTION,
+    "render-turn",
+    { "character:atlas", "component:active", "subagent:worker-1" }
+  };
+
+  assert(
+    vector_child_program_route_region(&request, &route) ==
+    VECTOR_CHILD_PROGRAM_STATUS_OK
+  );
+  assert(route.status == VECTOR_CHILD_PROGRAM_STATUS_OK);
+  assert(
+    strcmp(route.descriptor.program_id, "vector-main-interaction-program") == 0
+  );
+  assert(strcmp(route.cortex.character_id, "character:atlas") == 0);
+  assert(strcmp(route.cortex.component_id, "component:active") == 0);
+  assert(strcmp(route.cortex.subagent_instance_id, "subagent:worker-1") == 0);
+}
+
+static void test_main_interaction_rejects_missing_cortex_reference(void) {
+  vector_child_program_route route;
+  const vector_child_program_route_request request = {
+    VECTOR_CHILD_PROGRAM_RUNTIME_ABI_VERSION,
+    VECTOR_WORKSPACE_REGION_MAIN_INTERACTION,
+    "render-turn",
+    { "character:atlas", NULL, NULL }
+  };
+
+  assert(
+    vector_child_program_route_region(&request, &route) ==
+    VECTOR_CHILD_PROGRAM_STATUS_MISSING_CORTEX_REFERENCE
+  );
+  assert(route.status == VECTOR_CHILD_PROGRAM_STATUS_MISSING_CORTEX_REFERENCE);
+  assert(
+    strcmp(
+      vector_child_program_status_name(route.status),
+      "missing_cortex_reference"
+    ) == 0
+  );
+}
+
+static void test_unsupported_abi_rejected(void) {
+  vector_child_program_route route;
+  const vector_child_program_route_request request = {
+    VECTOR_CHILD_PROGRAM_RUNTIME_ABI_VERSION + 1u,
+    VECTOR_WORKSPACE_REGION_LEFT_MENU,
+    "open-workspace",
+    { 0 }
+  };
+
+  assert(
+    vector_child_program_route_region(&request, &route) ==
+    VECTOR_CHILD_PROGRAM_STATUS_UNSUPPORTED_ABI
+  );
+  assert(route.status == VECTOR_CHILD_PROGRAM_STATUS_UNSUPPORTED_ABI);
+  assert(strcmp(vector_child_program_status_name(route.status), "unsupported_abi") == 0);
+}
+
+static void test_null_and_unknown_inputs(void) {
+  vector_child_program_route route;
+  vector_child_program_descriptor descriptor;
+  const vector_child_program_route_request request = {
+    VECTOR_CHILD_PROGRAM_RUNTIME_ABI_VERSION,
+    (vector_workspace_region)99,
+    "open-workspace",
+    { 0 }
+  };
+
+  assert(
+    vector_child_program_at(99u, &descriptor) ==
+    VECTOR_CHILD_PROGRAM_STATUS_UNKNOWN_REGION
+  );
+  assert(
+    vector_child_program_at(0u, NULL) ==
+    VECTOR_CHILD_PROGRAM_STATUS_NULL_ARGUMENT
+  );
+  assert(
+    vector_child_program_route_region(NULL, &route) ==
+    VECTOR_CHILD_PROGRAM_STATUS_NULL_ARGUMENT
+  );
+  assert(route.status == VECTOR_CHILD_PROGRAM_STATUS_NULL_ARGUMENT);
+  assert(strcmp(route.status_message, "null argument") == 0);
+  assert(
+    vector_child_program_route_region(&request, &route) ==
+    VECTOR_CHILD_PROGRAM_STATUS_UNKNOWN_REGION
+  );
+  assert(strcmp(vector_workspace_region_name(request.region), "unknown_region") == 0);
+}
+
+static void test_name_helpers(void) {
+  assert(strcmp(vector_data_lane_name(VECTOR_DATA_LANE_DEVBASE), "devbase") == 0);
+  assert(
+    strcmp(
+      vector_workspace_region_name(VECTOR_WORKSPACE_REGION_MAIN_INTERACTION),
+      "main_interaction"
+    ) == 0
+  );
+  assert(
+    strcmp(
+      vector_child_program_status_name((vector_child_program_status)99),
+      "unknown_status"
+    ) == 0
+  );
+}
+
+int main(void) {
+  test_version_contract();
+  test_descriptor_table();
+  test_left_menu_routes_without_cortex_reference();
+  test_main_interaction_requires_cortex_reference();
+  test_main_interaction_rejects_missing_cortex_reference();
+  test_unsupported_abi_rejected();
+  test_null_and_unknown_inputs();
+  test_name_helpers();
+  return 0;
+}


### PR DESCRIPTION
﻿## Summary
- add the first executable Native C child-program runtime ABI for VECTOR
- add CMake/CTest build coverage for child-program routing
- route left-menu and main-interaction workspace regions through native descriptors while preserving CORTEX character/component ownership boundaries
- update VECTOR progress docs/README with the native runtime slice and build commands

## Why
The corrected execution lane is OpenClaw/Codex conversion into Native C component programs integrated through CORTEX and VECTOR. PR #7 landed the component assimilation map; this PR turns the first VECTOR runtime boundary into compiled/tested C code instead of remaining docs-only.

## Validation
- `cmake -S . -B "$env:LOCALAPPDATA\VECTOR\child-program-runtime-build"`
- `cmake --build "$env:LOCALAPPDATA\VECTOR\child-program-runtime-build" --config Debug`
- `ctest --test-dir "$env:LOCALAPPDATA\VECTOR\child-program-runtime-build" -C Debug --output-on-failure`
- `git diff --check -- CMakeLists.txt README.md docs include src tests`

## Follow-up
- connect the Avalonia host to the C ABI
- expand first-class runtime descriptors for session/tool/artifact child programs
- expose imported specialist helper assignment through the runtime route for #5
