### PR TITLE
Add native install rules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ project(VECTOR VERSION 0.1.0 LANGUAGES C)
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_C_EXTENSIONS OFF)
+include(GNUInstallDirs)
 
 add_library(vector_child_program_runtime STATIC
   src/child_program_runtime.c
@@ -80,3 +81,11 @@ add_test(NAME vector_host_assign_audit_only_fails
     tool-execution apply-patch)
 set_tests_properties(vector_host_assign_audit_only_fails
   PROPERTIES WILL_FAIL TRUE)
+
+install(TARGETS vector_child_program_runtime vector_host
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+install(FILES include/vector/child_program_runtime.h
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/vector)

--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ ctest --test-dir "$env:LOCALAPPDATA\VECTOR\child-program-runtime-build" -C Debug
 
 The same build creates `vector_host`, a native command surface for descriptor listing, route checks, and CORTEX host-state assignment previews.
 
+Install the native runtime library, public header, and `vector_host` into a staging prefix with:
+
+```powershell
+cmake --install "$env:LOCALAPPDATA\VECTOR\child-program-runtime-build" --config Debug --prefix "$env:LOCALAPPDATA\VECTOR\install-smoke"
+```
+
 ## Upstream Manifest
 
 Regenerate the local OpenAI Codex component manifest from the cloned source with:

--- a/docs/vector-runtime-topology-first-slice.md
+++ b/docs/vector-runtime-topology-first-slice.md
@@ -84,6 +84,7 @@ It is intentionally bounded. It does not describe every future subsystem. It def
 - CORTEX-to-VECTOR runtime export assignment now uses `vector_child_program_assign_cortex_export`, accepting CORTEX readiness flags and stable reference strings before handing the assignment to VECTOR's native session/tool helper-surface rules.
 - VECTOR can now consume persisted CORTEX host-state files through `vector_child_program_assign_cortex_state_file`, turning the first CORTEX operator host output into a native VECTOR assignment path for session/tool work.
 - `vector_host` provides the first native operator command surface over those descriptors and assignments, keeping the runtime exercisable before managed host interop arrives.
+- Native install rules now stage the runtime library, public C header, and `vector_host` executable, giving packaging work a concrete artifact boundary before full distribution installers.
 
 ## Completed next slice
 


### PR DESCRIPTION
﻿## Summary
- add CMake install rules for the VECTOR native runtime library, public header, and `vector_host`
- document an install-smoke command in the README
- update topology notes with the concrete native artifact boundary

## Why
VECTOR #4 needs packaging/distribution to distinguish native runtime artifacts from future host-shell artifacts. This PR adds the first installable native artifact layout before full installer work.

## Validation
- `cmake -S . -B "$env:LOCALAPPDATA\VECTOR\child-program-runtime-build"`
- `cmake --build "$env:LOCALAPPDATA\VECTOR\child-program-runtime-build" --config Debug`
- `ctest --test-dir "$env:LOCALAPPDATA\VECTOR\child-program-runtime-build" -C Debug --output-on-failure`
- `cmake --install "$env:LOCALAPPDATA\VECTOR\child-program-runtime-build" --config Debug --prefix "$env:LOCALAPPDATA\VECTOR\install-smoke"`
- verified installed files:
  - `bin\vector_host.exe`
  - `lib\vector_child_program_runtime.lib`
  - `include\vector\child_program_runtime.h`
- `git diff --check -- CMakeLists.txt README.md docs include src tests tools`

## Issue
Advances #4
