### PR TITLE
VECTOR: add installed CORTEX smoke gate

### DIFF
--- a/tools/run-installed-cortex-vector-smoke.ps1
+++ b/tools/run-installed-cortex-vector-smoke.ps1
@@ -1,0 +1,68 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$CortexHostPath,
+
+    [Parameter(Mandatory = $true)]
+    [string]$VectorHostPath,
+
+    [string]$WorkDir = (Join-Path $env:TEMP "symbiosis-cortex-vector-installed-smoke"),
+
+    [string]$StateFile
+)
+
+if (-not (Test-Path -LiteralPath $CortexHostPath)) {
+    Write-Error "cortex_host not found: $CortexHostPath"
+    exit 1
+}
+
+if (-not (Test-Path -LiteralPath $VectorHostPath)) {
+    Write-Error "vector_host not found: $VectorHostPath"
+    exit 1
+}
+
+New-Item -ItemType Directory -Path $WorkDir -Force | Out-Null
+
+if ([string]::IsNullOrWhiteSpace($StateFile)) {
+    $StateFile = Join-Path $WorkDir "cortex_host_demo.state"
+}
+
+& $CortexHostPath demo $StateFile
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "cortex_host demo failed for state file: $StateFile"
+    exit $LASTEXITCODE
+}
+
+if (-not (Test-Path -LiteralPath $StateFile)) {
+    Write-Error "Expected state file was not created: $StateFile"
+    exit 1
+}
+
+$assignOutput = & $VectorHostPath assign-state $StateFile tool-execution apply-patch 2>&1 | Out-String
+$exitCode = $LASTEXITCODE
+
+if ($exitCode -ne 0) {
+    Write-Error "vector_host assign-state failed with exit code: $exitCode"
+    Write-Error $assignOutput
+    exit $exitCode
+}
+
+$required = @(
+    "status=ok",
+    "program=vector-tool-execution-program",
+    "helper=host-demo-helper",
+    "character=character-alpha",
+    "component=component-active",
+    "subagent=subagent-host-demo"
+)
+
+foreach ($token in $required) {
+    if ($assignOutput -notlike "*$token*") {
+        Write-Error "Expected token missing: $token"
+        Write-Error $assignOutput
+        exit 2
+    }
+}
+
+Write-Output $assignOutput
+Write-Host "Installed CORTEX/VECTOR smoke passed."
+exit 0


### PR DESCRIPTION
﻿## Summary
- Adds a repeatable installed CORTEX/VECTOR smoke script for packaging validation.
- The script runs installed `cortex_host.exe demo`, passes the generated state to installed `vector_host.exe assign-state`, and fails if expected assignment tokens are missing.

## Verification
- `tools/run-installed-cortex-vector-smoke.ps1 -CortexHostPath C:\Users\Allan\AppData\Local\CORTEX\install-smoke\bin\cortex_host.exe -VectorHostPath C:\Users\Allan\AppData\Local\VECTOR\install-cross-smoke\bin\vector_host.exe -WorkDir C:\Users\Allan\AppData\Local\VECTOR\scripted-installed-smoke`
- Output included `status=ok`, `program=vector-tool-execution-program`, `helper=host-demo-helper`, `character=character-alpha`, `component=component-active`, and `subagent=subagent-host-demo`.

Supports VECTOR #4. Also provides evidence for VECTOR #2, #3, and #5.
