### PR TITLE
VECTOR: support catalog-backed installed smoke

### DIFF
--- a/tools/run-installed-cortex-vector-smoke.ps1
+++ b/tools/run-installed-cortex-vector-smoke.ps1
@@ -7,7 +7,13 @@ param(
 
     [string]$WorkDir = (Join-Path $env:TEMP "symbiosis-cortex-vector-installed-smoke"),
 
-    [string]$StateFile
+    [string]$StateFile,
+
+    [string]$CatalogPath,
+
+    [string]$ExpectedHelperId = "host-demo-helper",
+
+    [string]$ExpectedSubagentId = "subagent-host-demo"
 )
 
 if (-not (Test-Path -LiteralPath $CortexHostPath)) {
@@ -22,13 +28,26 @@ if (-not (Test-Path -LiteralPath $VectorHostPath)) {
 
 New-Item -ItemType Directory -Path $WorkDir -Force | Out-Null
 
-if ([string]::IsNullOrWhiteSpace($StateFile)) {
-    $StateFile = Join-Path $WorkDir "cortex_host_demo.state"
+if (-not [string]::IsNullOrWhiteSpace($CatalogPath) -and -not (Test-Path -LiteralPath $CatalogPath)) {
+    Write-Error "catalog TSV not found: $CatalogPath"
+    exit 1
 }
 
-& $CortexHostPath demo $StateFile
+if ([string]::IsNullOrWhiteSpace($StateFile)) {
+    if ([string]::IsNullOrWhiteSpace($CatalogPath)) {
+        $StateFile = Join-Path $WorkDir "cortex_host_demo.state"
+    } else {
+        $StateFile = Join-Path $WorkDir "cortex_host_catalog.state"
+    }
+}
+
+if ([string]::IsNullOrWhiteSpace($CatalogPath)) {
+    & $CortexHostPath demo $StateFile
+} else {
+    & $CortexHostPath bind-catalog $CatalogPath $StateFile
+}
 if ($LASTEXITCODE -ne 0) {
-    Write-Error "cortex_host demo failed for state file: $StateFile"
+    Write-Error "cortex_host state generation failed for state file: $StateFile"
     exit $LASTEXITCODE
 }
 
@@ -49,10 +68,10 @@ if ($exitCode -ne 0) {
 $required = @(
     "status=ok",
     "program=vector-tool-execution-program",
-    "helper=host-demo-helper",
+    "helper=$ExpectedHelperId",
     "character=character-alpha",
     "component=component-active",
-    "subagent=subagent-host-demo"
+    "subagent=$ExpectedSubagentId"
 )
 
 foreach ($token in $required) {


### PR DESCRIPTION
﻿## Summary
- Extends the installed CORTEX/VECTOR smoke script with optional catalog-backed mode.
- `-CatalogPath` now calls `cortex_host bind-catalog`; expected helper/subagent tokens can be supplied for catalog-derived assignments.
- Preserves the existing demo-mode defaults.

## Verification
- Demo mode passed with installed `cortex_host.exe demo` -> installed `vector_host.exe assign-state`.
- Catalog mode passed with installed `cortex_host.exe bind-catalog C:\KHYRON\apps\CORTEX\tests\fixtures\cortex_catalog_input.tsv` -> installed `vector_host.exe assign-state`.
- Catalog mode output included `status=ok`, `program=vector-tool-execution-program`, `helper=accepted-helper`, `character=character-alpha`, `component=component-active`, `subagent=accepted-helper`.

Supports VECTOR #4 with additional evidence for VECTOR #2, #3, and #5.
